### PR TITLE
Fix null quality parameter validation in PDF compress API

### DIFF
--- a/src/app/api/pdf/compress/route.ts
+++ b/src/app/api/pdf/compress/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate quality parameter
-    if (!['low', 'medium', 'high'].includes(quality)) {
+    if (!quality || !['low', 'medium', 'high'].includes(quality)) {
       return withCors(NextResponse.json(
         { error: 'Quality must be one of: low, medium, high' },
         { status: 400 }


### PR DESCRIPTION
## Purpose
Fix a TypeScript compilation error in the PDF compression API that was preventing successful builds. The build was failing due to improper null handling in the quality parameter validation logic.

## Code changes
- Added null check (`!quality`) before validating the quality parameter in the PDF compress route
- This prevents TypeScript error when `quality` parameter could be `null`
- Ensures proper validation flow for the quality parameter (`low`, `medium`, `high`)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/21f7dd8f32b84212955f430b5036dc66/spark-forge)

👀 [Preview Link](https://21f7dd8f32b84212955f430b5036dc66-spark-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>21f7dd8f32b84212955f430b5036dc66</projectId>-->
<!--<branchName>spark-forge</branchName>-->