### PR TITLE
Fix deployment errors

### DIFF
--- a/src/app/crop-pdf/page.tsx
+++ b/src/app/crop-pdf/page.tsx
@@ -28,6 +28,7 @@ export default function CropPDFPage() {
   const [result, setResult] = useState<CropResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [scope, setScope] = useState<'all' | 'current'>('current');
 
   // Configure PDF.js worker on client side only
   useEffect(() => {

--- a/src/components/crop-pdf/pdf-viewer-continuous.tsx
+++ b/src/components/crop-pdf/pdf-viewer-continuous.tsx
@@ -44,8 +44,13 @@ export function PdfViewerContinuous({ file, pageInfo, cropAreas, onCropAreaChang
   const [tempArea, setTempArea] = useState<{ [page: number]: CropArea }>({});
 
   // Editing state (move/resize) for persistent crop
-  const movingRef = useRef<{ page: number; startClientX: number; startClientY: number; startArea: CropArea } | null>(null);
-  const resizingRef = useRef<{ page: number; handle: ResizeHandle; startClientX: number; startClientY: number; startArea: CropArea } | null>(null);
+  const [moving, setMoving] = useState<{ page: number; startClientX: number; startClientY: number; startArea: CropArea } | null>(null);
+  const movingRef = useRef(moving);
+  movingRef.current = moving;
+
+  const [resizing, setResizing] = useState<{ page: number; handle: ResizeHandle; startClientX: number; startClientY: number; startArea: CropArea } | null>(null);
+  const resizingRef = useRef(resizing);
+  resizingRef.current = resizing;
 
   const scaleMapRef = useRef<Record<number, number>>({});
 


### PR DESCRIPTION
This commit fixes a series of build errors that were causing Vercel deployments to fail. The errors were all related to TypeScript type mismatches and missing state variables.

The following changes were made:

- In `src/app/api/pdf/crop/route.ts`:
  - Added a guard clause to handle the case where `filePath` is `null`.
  - Added a type guard to validate the `unit` property.
- In `src/app/crop-pdf/page.tsx`:
  - Added the missing `scope` state variable.
- In `src/components/crop-pdf/pdf-viewer-continuous.tsx`:
  - Added the missing `moving` and `resizing` state variables.

These changes resolve all known build errors and allow the application to be deployed successfully.