### PR TITLE
Add PDF editor with annotation and text editing tools

### DIFF
--- a/src/app/edit-pdf/page.tsx
+++ b/src/app/edit-pdf/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from 'react';
+import { MainLayout } from '@/components/layout/main-layout';
+import PdfEditor from '@/components/edit-pdf/pdf-editor';
+
+export default function EditPdfPage() {
+  return (
+    <MainLayout>
+      <section className="py-10">
+        <div className="mx-auto max-w-5xl px-4">
+          <h1 className="text-2xl font-semibold mb-2">Edit PDF</h1>
+          <p className="text-muted mb-6">Add text, draw, highlight, and shapes. Export as a flattened PDF. No upload to server.</p>
+        </div>
+        <PdfEditor />
+      </section>
+    </MainLayout>
+  );
+}

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -117,7 +117,7 @@ export default function PdfEditor() {
     setSelected({ page, id });
   }, [color, fontSize, pushHistory, toPdfPt, mode]);
 
-  const handleMouseDown = useCallback((page: number, e: React.MouseEvent) => {
+  const handleMouseDown = useCallback((page: number, e: React.MouseEvent) => { if (mode !== 'annotate') return;
     if (tool === 'pen' || tool === 'highlighter') {
       setIsDrawing(true);
       const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -185,7 +185,7 @@ export default function PdfEditor() {
       setAnnotations(prev => ({ ...prev, [page]: (prev[page]||[]).map(a => a.id === drag.id ? { ...a, x: drag.startX + dx, y: drag.startY + dy } as any : a) }));
       return;
     }
-  }, [annotations, isDrawing, toPdfPt]);
+  }, [annotations, isDrawing, toPdfPt, mode]);
 
   const handleMouseUp = useCallback(() => { setIsDrawing(false); draggingRef.current = null; }, []);
 

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -294,7 +294,7 @@ export default function PdfEditor() {
     const a = document.createElement('a');
     a.href = url; a.download = `edited_${file.name.replace(/\.[^.]+$/, '')}.pdf`; document.body.appendChild(a); a.click(); document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [annotations, file]);
+  }, [annotations, file, segments]);
 
   // Page load success -> compute scale mapping
   const onPageLoad = useCallback((pageNumber: number, page: any) => {

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -353,6 +353,17 @@ export default function PdfEditor() {
         }
         return false;
       });
+
+      if (!hit && mode === 'edit') {
+        const seg = (segments[pageNumber] || []).slice().reverse().find(s => x >= s.x && x <= s.x + s.w && yTop >= s.y && yTop <= s.y + s.h);
+        if (seg) {
+          setSelected({ page: pageNumber, id: seg.id });
+        } else {
+          setSelected(null);
+        }
+        return;
+      }
+
       if (hit) {
         setSelected({ page: pageNumber, id: hit.id });
         draggingRef.current = { page: pageNumber, id: hit.id, startX: (hit as any).x, startY: (hit as any).y, offX: x, offY: yTop };

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -260,6 +260,14 @@ export default function PdfEditor() {
         page.drawImage(png, { x: 0, y: 0, width, height, opacity: 1 });
       }
 
+      // Apply edited text segments first (redact then write)
+      for (const seg of (segments[pageNum] || []).filter(s => s.edited !== undefined && s.edited !== s.text)) {
+        const rx = seg.x;
+        const ry = (height - seg.y) - seg.h;
+        page.drawRectangle({ x: rx, y: ry, width: seg.w, height: seg.h, color: rgbFromString('#ffffff') });
+        page.drawText(seg.edited || '', { x: seg.x, y: (height - seg.y) - seg.h * 0.8, size: Math.max(10, seg.h * 0.8), font: helv, color: rgbFromString('#000000') });
+      }
+
       // Draw vector/text on top
       for (const a of anns) {
         if (a.type === 'rect') {

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import EditorToolbar from './toolbar';
+import { Annotation, PageViewportInfo, PenAnnotation, PenPoint, RectAnnotation, TextAnnotation, ToolType } from './types';
+import { DragDropZone } from '@/components/file-upload/drag-drop-zone';
+import { FILE_TYPES, MAX_FILE_SIZES } from '@/lib/constants/file-types';
+import { Button } from '@/components/ui/button';
+import { v4 as uuidv4 } from 'uuid';
+import 'react-pdf/dist/Page/TextLayer.css';
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+
+const Document = dynamic(() => import('react-pdf').then(m => m.Document), { ssr: false });
+const Page = dynamic(() => import('react-pdf').then(m => m.Page), { ssr: false });
+
+if (typeof window !== 'undefined') {
+  import('react-pdf').then(({ pdfjs }) => {
+    pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+  });
+}
+
+const TARGET_WIDTH = 720; // display width per page
+
+export default function PdfEditor() {
+  const [file, setFile] = useState<File | null>(null);
+  const [pdfData, setPdfData] = useState<ArrayBuffer | null>(null);
+  const [numPages, setNumPages] = useState(0);
+  const [viewport, setViewport] = useState<PageViewportInfo[]>([]);
+
+  const [tool, setTool] = useState<ToolType>('select');
+  const [color, setColor] = useState('#ff4757');
+  const [strokeWidth, setStrokeWidth] = useState(3);
+  const [fontSize, setFontSize] = useState(18);
+
+  const [annotations, setAnnotations] = useState<Record<number, Annotation[]>>({});
+  const [selected, setSelected] = useState<{ page: number; id: string } | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const historyRef = useRef<Annotation[][]>([]);
+  const futureRef = useRef<Annotation[][]>([]);
+
+  const scaleFor = useCallback((page: number) => {
+    const info = viewport.find(v => v.pageNumber === page);
+    return info?.scale || 1;
+  }, [viewport]);
+
+  const toPdfPt = useCallback((page: number, xPx: number, yPx: number) => {
+    const s = scaleFor(page);
+    const pdfX = xPx / s;
+    const info = viewport.find(v => v.pageNumber === page)!;
+    const pdfYFromTop = yPx / s; // store from top
+    return { x: pdfX, yTop: pdfYFromTop, height: info.pdfHeight };
+  }, [scaleFor, viewport]);
+
+  const pushHistory = useCallback(() => {
+    const snapshot = Object.values(annotations).flat();
+    historyRef.current.push(JSON.parse(JSON.stringify(snapshot)));
+    futureRef.current = [];
+  }, [annotations]);
+
+  const undo = useCallback(() => {
+    if (!historyRef.current.length) return;
+    const current = Object.values(annotations).flat();
+    futureRef.current.push(current);
+    const prev = historyRef.current.pop()!;
+    const grouped: Record<number, Annotation[]> = {};
+    for (const a of prev) {
+      grouped[a.page] = grouped[a.page] || [];
+      grouped[a.page].push(a);
+    }
+    setAnnotations(grouped);
+    setSelected(null);
+  }, [annotations]);
+
+  const redo = useCallback(() => {
+    if (!futureRef.current.length) return;
+    const next = futureRef.current.pop()!;
+    historyRef.current.push(Object.values(annotations).flat());
+    const grouped: Record<number, Annotation[]> = {};
+    for (const a of next) {
+      grouped[a.page] = grouped[a.page] || [];
+      grouped[a.page].push(a);
+    }
+    setAnnotations(grouped);
+  }, [annotations]);
+
+  const onFilesSelected = useCallback((files: File[]) => {
+    if (!files.length) return;
+    const f = files[0];
+    setFile(f);
+    f.arrayBuffer().then(setPdfData).catch(console.error);
+  }, []);
+
+  const startText = useCallback((page: number, e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+    const xPx = e.clientX - rect.left;
+    const yPx = e.clientY - rect.top;
+    const conv = toPdfPt(page, xPx, yPx);
+    const id = uuidv4();
+    const text: TextAnnotation = {
+      id,
+      page,
+      type: 'text',
+      x: conv.x,
+      y: conv.yTop,
+      w: 200,
+      h: fontSize * 1.4,
+      opacity: 1,
+      color,
+      z: Date.now(),
+      text: 'Edit text',
+      fontSize,
+      font: 'Helvetica'
+    };
+    pushHistory();
+    setAnnotations(prev => ({ ...prev, [page]: [...(prev[page] || []), text] }));
+    setSelected({ page, id });
+  }, [color, fontSize, pushHistory, toPdfPt]);
+
+  const handleMouseDown = useCallback((page: number, e: React.MouseEvent) => {
+    if (tool === 'pen' || tool === 'highlighter') {
+      setIsDrawing(true);
+      const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+      const xPx = e.clientX - rect.left;
+      const yPx = e.clientY - rect.top;
+      const { x, yTop } = toPdfPt(page, xPx, yPx);
+      const id = uuidv4();
+      const ann: PenAnnotation = {
+        id,
+        page,
+        type: tool,
+        opacity: tool === 'highlighter' ? 0.35 : 1,
+        color,
+        z: Date.now(),
+        w: 0,
+        h: 0,
+        points: [{ x, y: yTop }],
+        strokeWidth: Math.max(1, strokeWidth)
+      };
+      pushHistory();
+      setAnnotations(prev => ({ ...prev, [page]: [...(prev[page] || []), ann] }));
+    } else if (tool === 'rect') {
+      setIsDrawing(true);
+      const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+      const xPx = e.clientX - rect.left;
+      const yPx = e.clientY - rect.top;
+      const { x, yTop } = toPdfPt(page, xPx, yPx);
+      const id = uuidv4();
+      const ann: RectAnnotation = { id, page, type: 'rect', x, y: yTop, w: 1, h: 1, opacity: 1, color, z: Date.now(), strokeWidth: Math.max(1, strokeWidth) };
+      pushHistory();
+      setAnnotations(prev => ({ ...prev, [page]: [...(prev[page] || []), ann] }));
+    } else if (tool === 'text') {
+      startText(page, e);
+    }
+  }, [tool, color, strokeWidth, toPdfPt, startText, pushHistory]);
+
+  const handleMouseMove = useCallback((page: number, e: React.MouseEvent) => {
+    if (!isDrawing) return;
+    const list = annotations[page];
+    if (!list || !list.length) return;
+    const current = list[list.length - 1];
+    const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+    const xPx = e.clientX - rect.left;
+    const yPx = e.clientY - rect.top;
+    const { x, yTop } = toPdfPt(page, xPx, yPx);
+
+    if (current.type === 'pen' || current.type === 'highlighter') {
+      const pen = current as PenAnnotation;
+      setAnnotations(prev => ({ ...prev, [page]: [...list.slice(0, -1), { ...pen, points: [...pen.points, { x, y: yTop }] }] }));
+    } else if (current.type === 'rect') {
+      const r = current as RectAnnotation;
+      setAnnotations(prev => ({ ...prev, [page]: [...list.slice(0, -1), { ...r, w: x - r.x, h: yTop - r.y }] }));
+    }
+  }, [annotations, isDrawing, toPdfPt]);
+
+  const handleMouseUp = useCallback(() => setIsDrawing(false), []);
+
+  const onTextChange = useCallback((page: number, id: string, text: string) => {
+    setAnnotations(prev => ({ ...prev, [page]: (prev[page] || []).map(a => a.id === id && a.type === 'text' ? { ...(a as TextAnnotation), text } : a) }));
+  }, []);
+
+  const onDelete = useCallback(() => {
+    if (!selected) return;
+    const { page, id } = selected;
+    pushHistory();
+    setAnnotations(prev => ({ ...prev, [page]: (prev[page] || []).filter(a => a.id !== id) }));
+    setSelected(null);
+  }, [selected, pushHistory]);
+
+  const clearAll = useCallback(() => {
+    pushHistory();
+    setAnnotations({});
+    setSelected(null);
+  }, [pushHistory]);
+
+  const exportPdf = useCallback(async () => {
+    if (!file || !pdfData) return;
+    const { PDFDocument, rgb, StandardFonts } = await import('pdf-lib');
+    const orig = await PDFDocument.load(pdfData);
+    const helv = await orig.embedFont(StandardFonts.Helvetica);
+    const times = await orig.embedFont(StandardFonts.TimesRoman);
+
+    const pages = orig.getPages();
+
+    // Helper: draw pen/highlighter by rasterizing to PNG per page
+    for (let i = 0; i < pages.length; i++) {
+      const pageNum = i + 1;
+      const page = pages[i];
+      const { width, height } = page.getSize();
+      const anns = (annotations[pageNum] || []).sort((a,b) => a.z - b.z);
+
+      // Offscreen canvas for strokes
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.ceil(width);
+      canvas.height = Math.ceil(height);
+      const ctx = canvas.getContext('2d')!;
+      ctx.clearRect(0,0,canvas.width, canvas.height);
+
+      for (const a of anns) {
+        if (a.type === 'pen' || a.type === 'highlighter') {
+          const pen = a as PenAnnotation;
+          if (pen.points.length < 2) continue;
+          ctx.globalAlpha = pen.opacity;
+          ctx.strokeStyle = pen.color;
+          ctx.lineWidth = pen.strokeWidth;
+          ctx.lineJoin = 'round';
+          ctx.lineCap = 'round';
+          ctx.beginPath();
+          const start = pen.points[0];
+          ctx.moveTo(start.x, height - start.y);
+          for (let j = 1; j < pen.points.length; j++) {
+            const p = pen.points[j];
+            ctx.lineTo(p.x, height - p.y);
+          }
+          ctx.stroke();
+          ctx.globalAlpha = 1;
+        }
+      }
+
+      // Embed raster if any pixels drawn
+      const hasPixels = (() => {
+        const imgData = ctx.getImageData(0,0,1,1).data; // cheap touch
+        return true; // always embed; simpler and safe
+      })();
+
+      if (hasPixels) {
+        const pngBytes = await new Promise<Uint8Array>(resolve => canvas.toBlob(async (blob) => resolve(new Uint8Array(await blob!.arrayBuffer())), 'image/png'));
+        const png = await orig.embedPng(pngBytes);
+        page.drawImage(png, { x: 0, y: 0, width, height, opacity: 1 });
+      }
+
+      // Draw vector/text on top
+      for (const a of anns) {
+        if (a.type === 'rect') {
+          const r = a as RectAnnotation;
+          page.drawRectangle({ x: Math.min(r.x, r.x + r.w), y: Math.min(r.y, r.y + r.h) * -1 + height, width: Math.abs(r.w), height: Math.abs(r.h), color: undefined, borderWidth: r.strokeWidth, borderColor: rgbFromString(a.color), opacity: a.opacity });
+        }
+        if (a.type === 'text') {
+          const t = a as TextAnnotation;
+          const f = t.font === 'Helvetica' ? helv : times;
+          page.drawText(t.text || '', { x: t.x, y: height - t.y - t.h + (t.fontSize*0.2), size: t.fontSize, font: f, color: rgbFromString(t.color), opacity: t.opacity });
+        }
+      }
+    }
+
+    const bytes = await orig.save();
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `edited_${file.name.replace(/\.[^.]+$/, '')}.pdf`; document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [annotations, file, pdfData]);
+
+  // Page load success -> compute scale mapping
+  const onPageLoad = useCallback((pageNumber: number, page: any) => {
+    const vp = page.getViewport({ scale: 1 });
+    const s = TARGET_WIDTH / vp.width;
+    setViewport(prev => {
+      const next = prev.filter(p => p.pageNumber !== pageNumber);
+      next.push({ pageNumber, pdfWidth: vp.width, pdfHeight: vp.height, scale: s });
+      return [...next];
+    });
+  }, []);
+
+  const renderOverlay = useCallback((pageNumber: number) => {
+    const anns = annotations[pageNumber] || [];
+    const info = viewport.find(v => v.pageNumber === pageNumber);
+    if (!info) return null;
+    const s = info.scale;
+
+    return (
+      <div className="absolute inset-0" onMouseDown={(e) => handleMouseDown(pageNumber, e)} onMouseMove={(e) => handleMouseMove(pageNumber, e)} onMouseUp={handleMouseUp}>
+        <svg className="absolute inset-0 w-full h-full" viewBox={`0 0 ${info.pdfWidth} ${info.pdfHeight}`} style={{ transform: `scale(${s})`, transformOrigin: 'top left', pointerEvents: 'none' }}>
+          {anns.map(a => {
+            if (a.type === 'pen' || a.type === 'highlighter') {
+              const p = a as PenAnnotation;
+              const d = p.points.map((pt, i) => `${i === 0 ? 'M' : 'L'} ${pt.x} ${pt.y}`).join(' ');
+              return <path key={a.id} d={d} stroke={a.color} strokeWidth={p.strokeWidth} fill="none" opacity={a.opacity} strokeLinecap="round" strokeLinejoin="round" />;
+            }
+            if (a.type === 'rect') {
+              const r = a as RectAnnotation;
+              return <rect key={a.id} x={Math.min(r.x, r.x + r.w)} y={Math.min(r.y, r.y + r.h)} width={Math.abs(r.w)} height={Math.abs(r.h)} fill="none" stroke={a.color} strokeWidth={r.strokeWidth} opacity={a.opacity} />;
+            }
+            if (a.type === 'text') {
+              const t = a as TextAnnotation;
+              return (
+                <foreignObject key={a.id} x={t.x} y={t.y} width={Math.max(50, t.w)} height={Math.max(20, t.h)}>
+                  <div style={{ pointerEvents: 'auto' }}>
+                    <input
+                      value={t.text}
+                      onChange={(e) => onTextChange(pageNumber, t.id, e.target.value)}
+                      className="w-full bg-transparent border border-border rounded px-1 text-foreground"
+                      style={{ color: t.color, fontSize: t.fontSize, lineHeight: 1.2 }}
+                    />
+                  </div>
+                </foreignObject>
+              );
+            }
+            return null;
+          })}
+        </svg>
+      </div>
+    );
+  }, [annotations, viewport, handleMouseDown, handleMouseMove, handleMouseUp, onTextChange]);
+
+  return (
+    <div className="w-full">
+      <EditorToolbar
+        tool={tool}
+        setTool={setTool}
+        color={color}
+        setColor={setColor}
+        strokeWidth={strokeWidth}
+        setStrokeWidth={setStrokeWidth}
+        fontSize={fontSize}
+        setFontSize={setFontSize}
+        undo={undo}
+        redo={redo}
+        canUndo={historyRef.current.length > 0}
+        canRedo={futureRef.current.length > 0}
+        onExport={exportPdf}
+        onClear={clearAll}
+        disabled={!file}
+      />
+
+      {!file && (
+        <div className="mx-auto max-w-3xl px-4 py-10">
+          <DragDropZone onFilesSelected={onFilesSelected} acceptedTypes={[FILE_TYPES.PDF]} maxFileSize={MAX_FILE_SIZES.PDF} maxFiles={1} />
+          <div className="mt-4 text-sm text-muted">Upload a PDF to start editing. Use the toolbar to add text, draw, highlight, or add shapes.</div>
+        </div>
+      )}
+
+      {file && pdfData && (
+        <div className="mx-auto max-w-5xl px-4 py-10">
+          <Document file={{ data: pdfData }} onLoadSuccess={(info: { numPages: number }) => setNumPages(info.numPages)} loading={<div className="p-6 text-muted-foreground">Loading PDF…</div>}>
+            {Array.from({ length: numPages }, (_, i) => i + 1).map((pageNumber) => (
+              <div key={pageNumber} className="relative mx-auto bg-white shadow-sm border border-border rounded-md overflow-hidden mb-8" style={{ width: '100%', maxWidth: TARGET_WIDTH }}>
+                <div className="relative" onDoubleClick={(e) => tool === 'text' && startText(pageNumber, e)}>
+                  <Page pageNumber={pageNumber} width={TARGET_WIDTH} renderTextLayer={false} renderAnnotationLayer={false} className="block mx-auto" onLoadSuccess={(page) => onPageLoad(pageNumber, page)} />
+                  {renderOverlay(pageNumber)}
+                </div>
+              </div>
+            ))}
+          </Document>
+
+          <div className="flex justify-center">
+            <Button variant="outline" onClick={() => { setFile(null); setPdfData(null); setAnnotations({}); setNumPages(0); }}>Choose another PDF</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function rgbFromString(color: string) {
+  // Accept #rrggbb or rgb(r,g,b)
+  if (color.startsWith('#')) {
+    const r = parseInt(color.substring(1,3),16)/255;
+    const g = parseInt(color.substring(3,5),16)/255;
+    const b = parseInt(color.substring(5,7),16)/255;
+    return (awaitRgb()).rgb(r,g,b);
+  }
+  const m = color.match(/rgb\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\)/i);
+  if (m) {
+    const r = parseInt(m[1],10)/255, g = parseInt(m[2],10)/255, b = parseInt(m[3],10)/255;
+    return (awaitRgb()).rgb(r,g,b);
+  }
+  return (awaitRgb()).rgb(0,0,0);
+}
+
+function awaitRgb(){
+  // Lazy import pdf-lib's rgb helper
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('pdf-lib');
+  return mod;
+}

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -115,7 +115,7 @@ export default function PdfEditor() {
     pushHistory();
     setAnnotations(prev => ({ ...prev, [page]: [...(prev[page] || []), text] }));
     setSelected({ page, id });
-  }, [color, fontSize, pushHistory, toPdfPt]);
+  }, [color, fontSize, pushHistory, toPdfPt, mode]);
 
   const handleMouseDown = useCallback((page: number, e: React.MouseEvent) => {
     if (tool === 'pen' || tool === 'highlighter') {

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -91,7 +91,7 @@ export default function PdfEditor() {
     setFile(f);
   }, []);
 
-  const startText = useCallback((page: number, e: React.MouseEvent) => {
+  const startText = useCallback((page: number, e: React.MouseEvent) => { if (mode !== 'annotate') return;
     const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
     const xPx = e.clientX - rect.left;
     const yPx = e.clientY - rect.top;

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -452,6 +452,8 @@ export default function PdfEditor() {
       {file && (
         <>
           <EditorToolbar
+            mode={mode}
+            setMode={setMode}
             tool={tool}
             setTool={setTool}
             color={color}

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -330,8 +330,14 @@ export default function PdfEditor() {
     };
 
     return (
-      <div className="absolute inset-0" onMouseDown={onOverlayMouseDown} onMouseMove={(e) => handleMouseMove(pageNumber, e)} onMouseUp={handleMouseUp}>
-        <svg className="absolute inset-0 w-full h-full" viewBox={`0 0 ${info.pdfWidth} ${info.pdfHeight}`} style={{ transform: `scale(${s})`, transformOrigin: 'top left', pointerEvents: 'none' }}>
+      <div className="absolute left-0 top-0 right-0 bottom-0" onMouseDown={onOverlayMouseDown} onMouseMove={(e) => handleMouseMove(pageNumber, e)} onMouseUp={handleMouseUp}>
+        <svg
+          className="absolute left-0 top-0"
+          viewBox={`0 0 ${info.pdfWidth} ${info.pdfHeight}`}
+          width={info.pdfWidth * s}
+          height={info.pdfHeight * s}
+          style={{ pointerEvents: 'none' }}
+        >
           {anns.map(a => {
             if (a.type === 'pen' || a.type === 'highlighter') {
               const p = a as PenAnnotation;

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -270,7 +270,7 @@ export default function PdfEditor() {
     const a = document.createElement('a');
     a.href = url; a.download = `edited_${file.name.replace(/\.[^.]+$/, '')}.pdf`; document.body.appendChild(a); a.click(); document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [annotations, file, pdfData]);
+  }, [annotations, file]);
 
   // Page load success -> compute scale mapping
   const onPageLoad = useCallback((pageNumber: number, page: any) => {

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -323,6 +323,10 @@ export default function PdfEditor() {
     }).catch(() => {});
   }, []);
 
+  const onTextSegmentChange = useCallback((page: number, id: string, text: string) => {
+    setSegments(prev => ({ ...prev, [page]: (prev[page]||[]).map(s => s.id === id ? { ...s, edited: text } : s) }));
+  }, []);
+
   const renderOverlay = useCallback((pageNumber: number) => {
     const anns = annotations[pageNumber] || [];
     const info = viewport.find(v => v.pageNumber === pageNumber);

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -32,11 +32,13 @@ export default function PdfEditor() {
   const [strokeWidth, setStrokeWidth] = useState(3);
   const [fontSize, setFontSize] = useState(18);
 
+  const [mode, setMode] = useState<'annotate' | 'edit'>('annotate');
   const [annotations, setAnnotations] = useState<Record<number, Annotation[]>>({});
   const [selected, setSelected] = useState<{ page: number; id: string } | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
   const historyRef = useRef<Annotation[][]>([]);
   const futureRef = useRef<Annotation[][]>([]);
+  const [segments, setSegments] = useState<Record<number, { id: string; x: number; y: number; w: number; h: number; text: string; fontSize: number; edited?: string }[]>>({});
 
   const scaleFor = useCallback((page: number) => {
     const info = viewport.find(v => v.pageNumber === page);

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -267,7 +267,7 @@ export default function PdfEditor() {
           const rw = Math.abs(r.w);
           const rh = Math.abs(r.h);
           const ry = (height - ryTop) - rh;
-          page.drawRectangle({ x: rx, y: ry, width: rw, height: rh, color: undefined, borderWidth: r.strokeWidth, borderColor: rgbFromString(a.color), opacity: a.opacity });
+          page.drawRectangle({ x: rx, y: ry, width: rw, height: rh, color: r.filled ? rgbFromString(r.fill || '#ffffff') : undefined, borderWidth: r.strokeWidth, borderColor: rgbFromString(a.color), opacity: a.opacity });
         }
         if (a.type === 'text') {
           const t = a as TextAnnotation;

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -153,7 +153,7 @@ export default function PdfEditor() {
     } else if (tool === 'text') {
       startText(page, e);
     }
-  }, [tool, color, strokeWidth, toPdfPt, startText, pushHistory]);
+  }, [tool, color, strokeWidth, toPdfPt, startText, pushHistory, mode]);
 
   const draggingRef = useRef<{ page: number; id: string; startX: number; startY: number; offX: number; offY: number } | null>(null);
 

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -438,7 +438,7 @@ export default function PdfEditor() {
         </svg>
       </div>
     );
-  }, [annotations, viewport, handleMouseDown, handleMouseMove, handleMouseUp, onTextChange, selected, tool, toPdfPt]);
+  }, [annotations, viewport, handleMouseDown, handleMouseMove, handleMouseUp, onTextChange, selected, tool, toPdfPt, mode, segments, onTextSegmentChange]);
 
   return (
     <div className="w-full">

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -381,7 +381,27 @@ export default function PdfEditor() {
           height={info.pdfHeight * s}
           style={{ pointerEvents: 'none' }}
         >
-          {anns.map(a => {
+          {mode === 'edit' && (segments[pageNumber] || []).map(seg => {
+            const isSelected = selected && selected.id === seg.id && selected.page === pageNumber;
+            return (
+              <g key={seg.id}>
+                <rect x={seg.x} y={seg.y} width={seg.w} height={seg.h} fill={isSelected ? 'rgba(59,130,246,0.15)' : 'rgba(0,0,0,0.06)'} stroke={isSelected ? '#3b82f6' : 'none'} />
+                {isSelected && (
+                  <foreignObject x={seg.x} y={seg.y} width={seg.w} height={seg.h}>
+                    <div style={{ pointerEvents: 'auto' }}>
+                      <input
+                        value={seg.edited ?? seg.text}
+                        onChange={(e) => onTextSegmentChange(pageNumber, seg.id, e.target.value)}
+                        className="w-full bg-white/90 border border-border rounded px-1 text-foreground"
+                        style={{ fontSize: Math.max(10, seg.h * 0.8) }}
+                      />
+                    </div>
+                  </foreignObject>
+                )}
+              </g>
+            );
+          })}
+          {mode === 'annotate' && anns.map(a => {
             if (a.type === 'pen' || a.type === 'highlighter') {
               const p = a as PenAnnotation;
               const d = p.points.map((pt, i) => `${i === 0 ? 'M' : 'L'} ${pt.x} ${pt.y}`).join(' ');

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -334,7 +334,9 @@ export default function PdfEditor() {
     const s = info.scale;
 
     const onOverlayMouseDown = (e: React.MouseEvent) => {
-      if (tool !== 'select') return handleMouseDown(pageNumber, e);
+      if (mode === 'annotate') {
+        if (tool !== 'select') return handleMouseDown(pageNumber, e);
+      }
       const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
       const xPx = e.clientX - rect.left;
       const yPx = e.clientY - rect.top;

--- a/src/components/edit-pdf/pdf-editor.tsx
+++ b/src/components/edit-pdf/pdf-editor.tsx
@@ -326,24 +326,6 @@ export default function PdfEditor() {
 
   return (
     <div className="w-full">
-      <EditorToolbar
-        tool={tool}
-        setTool={setTool}
-        color={color}
-        setColor={setColor}
-        strokeWidth={strokeWidth}
-        setStrokeWidth={setStrokeWidth}
-        fontSize={fontSize}
-        setFontSize={setFontSize}
-        undo={undo}
-        redo={redo}
-        canUndo={historyRef.current.length > 0}
-        canRedo={futureRef.current.length > 0}
-        onExport={exportPdf}
-        onClear={clearAll}
-        disabled={!file}
-      />
-
       {!file && (
         <div className="mx-auto max-w-3xl px-4 py-10">
           <DragDropZone onFilesSelected={onFilesSelected} acceptedTypes={[FILE_TYPES.PDF]} maxFileSize={MAX_FILE_SIZES.PDF} maxFiles={1} />
@@ -352,7 +334,25 @@ export default function PdfEditor() {
       )}
 
       {file && (
-        <div className="mx-auto max-w-5xl px-4 py-10">
+        <>
+          <EditorToolbar
+            tool={tool}
+            setTool={setTool}
+            color={color}
+            setColor={setColor}
+            strokeWidth={strokeWidth}
+            setStrokeWidth={setStrokeWidth}
+            fontSize={fontSize}
+            setFontSize={setFontSize}
+            undo={undo}
+            redo={redo}
+            canUndo={historyRef.current.length > 0}
+            canRedo={futureRef.current.length > 0}
+            onExport={exportPdf}
+            onClear={clearAll}
+            disabled={false}
+          />
+          <div className="mx-auto max-w-5xl px-4 py-10">
           <Document file={file} onLoadSuccess={(info: { numPages: number }) => setNumPages(info.numPages)} loading={<div className="p-6 text-muted-foreground">Loading PDF…</div>}>
             {Array.from({ length: numPages }, (_, i) => i + 1).map((pageNumber) => (
               <div key={pageNumber} className="relative mx-auto bg-white shadow-sm border border-border rounded-md overflow-hidden mb-8" style={{ width: '100%', maxWidth: TARGET_WIDTH }}>
@@ -368,6 +368,7 @@ export default function PdfEditor() {
             <Button variant="outline" onClick={() => { setFile(null); setAnnotations({}); setNumPages(0); }}>Choose another PDF</Button>
           </div>
         </div>
+        </>
       )}
     </div>
   );

--- a/src/components/edit-pdf/toolbar.tsx
+++ b/src/components/edit-pdf/toolbar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { Pencil, Highlighter, Type, Square, MoveLeft, MoveRight, Download, Trash2, MousePointer } from 'lucide-react';
+import { ToolType } from './types';
+
+interface ToolbarProps {
+  tool: ToolType;
+  setTool: (t: ToolType) => void;
+  color: string;
+  setColor: (c: string) => void;
+  strokeWidth: number;
+  setStrokeWidth: (n: number) => void;
+  fontSize: number;
+  setFontSize: (n: number) => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  onExport: () => void;
+  onClear: () => void;
+  disabled?: boolean;
+}
+
+export default function EditorToolbar({ tool, setTool, color, setColor, strokeWidth, setStrokeWidth, fontSize, setFontSize, undo, redo, canUndo, canRedo, onExport, onClear, disabled }: ToolbarProps) {
+  return (
+    <div className="sticky top-20 z-30 w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto max-w-5xl px-4 py-2 flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Button size="sm" variant={tool === 'select' ? 'default' : 'outline'} onClick={() => setTool('select')} disabled={disabled}>
+            <MousePointer className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant={tool === 'text' ? 'default' : 'outline'} onClick={() => setTool('text')} disabled={disabled}>
+            <Type className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant={tool === 'pen' ? 'default' : 'outline'} onClick={() => setTool('pen')} disabled={disabled}>
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant={tool === 'highlighter' ? 'default' : 'outline'} onClick={() => setTool('highlighter')} disabled={disabled}>
+            <Highlighter className="h-4 w-4" />
+          </Button>
+          <Button size="sm" variant={tool === 'rect' ? 'default' : 'outline'} onClick={() => setTool('rect')} disabled={disabled}>
+            <Square className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2 pl-2">
+          <label className="text-xs text-muted">Color</label>
+          <input type="color" value={color} onChange={(e) => setColor(e.target.value)} className="h-8 w-10 rounded border border-border bg-surface" disabled={disabled} />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-muted">Size</label>
+          <input type="range" min={1} max={32} value={strokeWidth} onChange={(e) => setStrokeWidth(parseInt(e.target.value))} disabled={disabled} />
+          <span className="text-xs text-muted w-6">{strokeWidth}</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-muted">Font</label>
+          <select value={fontSize} onChange={(e) => setFontSize(parseInt(e.target.value))} className="h-8 rounded border border-border bg-surface px-2 text-sm" disabled={disabled}>
+            {[12,14,16,18,20,24,28,32].map(s => <option key={s} value={s}>{s}px</option>)}
+          </select>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <Button size="sm" variant="outline" onClick={undo} disabled={!canUndo || disabled}><MoveLeft className="h-4 w-4" /></Button>
+          <Button size="sm" variant="outline" onClick={redo} disabled={!canRedo || disabled}><MoveRight className="h-4 w-4" /></Button>
+          <Button size="sm" variant="outline" onClick={onClear} disabled={disabled}><Trash2 className="h-4 w-4" /></Button>
+          <Button size="sm" onClick={onExport} disabled={disabled}><Download className="h-4 w-4 mr-1" />Export PDF</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/edit-pdf/toolbar.tsx
+++ b/src/components/edit-pdf/toolbar.tsx
@@ -5,7 +5,11 @@ import { Button } from '@/components/ui/button';
 import { Pencil, Highlighter, Type, Square, MoveLeft, MoveRight, Download, Trash2, MousePointer, Eraser } from 'lucide-react';
 import { ToolType } from './types';
 
+type Mode = 'annotate' | 'edit';
+
 interface ToolbarProps {
+  mode: Mode;
+  setMode: (m: Mode) => void;
   tool: ToolType;
   setTool: (t: ToolType) => void;
   color: string;
@@ -23,10 +27,14 @@ interface ToolbarProps {
   disabled?: boolean;
 }
 
-export default function EditorToolbar({ tool, setTool, color, setColor, strokeWidth, setStrokeWidth, fontSize, setFontSize, undo, redo, canUndo, canRedo, onExport, onClear, disabled }: ToolbarProps) {
+export default function EditorToolbar({ mode, setMode, tool, setTool, color, setColor, strokeWidth, setStrokeWidth, fontSize, setFontSize, undo, redo, canUndo, canRedo, onExport, onClear, disabled }: ToolbarProps) {
   return (
     <div className="sticky top-20 z-30 w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="mx-auto max-w-5xl px-4 py-2 flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Button size="sm" variant={mode === 'annotate' ? 'default' : 'outline'} onClick={() => setMode('annotate')} disabled={disabled}>Annotate</Button>
+          <Button size="sm" variant={mode === 'edit' ? 'default' : 'outline'} onClick={() => setMode('edit')} disabled={disabled}>Edit</Button>
+        </div>
         <div className="flex items-center gap-1">
           <Button size="sm" variant={tool === 'select' ? 'default' : 'outline'} onClick={() => setTool('select')} disabled={disabled}>
             <MousePointer className="h-4 w-4" />

--- a/src/components/edit-pdf/toolbar.tsx
+++ b/src/components/edit-pdf/toolbar.tsx
@@ -43,6 +43,9 @@ export default function EditorToolbar({ tool, setTool, color, setColor, strokeWi
           <Button size="sm" variant={tool === 'rect' ? 'default' : 'outline'} onClick={() => setTool('rect')} disabled={disabled}>
             <Square className="h-4 w-4" />
           </Button>
+          <Button size="sm" variant={tool === 'redact' ? 'default' : 'outline'} onClick={() => setTool('redact')} disabled={disabled}>
+            <Eraser className="h-4 w-4" />
+          </Button>
         </div>
 
         <div className="flex items-center gap-2 pl-2">

--- a/src/components/edit-pdf/toolbar.tsx
+++ b/src/components/edit-pdf/toolbar.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Pencil, Highlighter, Type, Square, MoveLeft, MoveRight, Download, Trash2, MousePointer } from 'lucide-react';
+import { Pencil, Highlighter, Type, Square, MoveLeft, MoveRight, Download, Trash2, MousePointer, Eraser } from 'lucide-react';
 import { ToolType } from './types';
 
 interface ToolbarProps {

--- a/src/components/edit-pdf/types.ts
+++ b/src/components/edit-pdf/types.ts
@@ -1,0 +1,49 @@
+export type ToolType = 'select' | 'text' | 'pen' | 'highlighter' | 'rect';
+
+export interface BaseAnnotation {
+  id: string;
+  page: number;
+  x: number; // PDF units (points)
+  y: number; // from top in PDF units
+  w: number;
+  h: number;
+  rotation?: number;
+  opacity: number;
+  color: string; // hex or rgb string
+  z: number;
+  type: ToolType;
+}
+
+export interface TextAnnotation extends BaseAnnotation {
+  type: 'text';
+  text: string;
+  fontSize: number;
+  font: 'Helvetica' | 'TimesRoman';
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+}
+
+export interface PenPoint { x: number; y: number; }
+
+export interface PenAnnotation extends BaseAnnotation {
+  type: 'pen' | 'highlighter';
+  points: PenPoint[]; // in PDF units
+  strokeWidth: number; // in PDF units
+}
+
+export interface RectAnnotation extends BaseAnnotation {
+  type: 'rect';
+  strokeWidth: number;
+  fill?: string;
+  filled?: boolean;
+}
+
+export type Annotation = TextAnnotation | PenAnnotation | RectAnnotation;
+
+export interface PageViewportInfo {
+  pageNumber: number;
+  pdfWidth: number; // in PDF points
+  pdfHeight: number; // in PDF points
+  scale: number; // displayPixels / pdf points for width
+}

--- a/src/components/edit-pdf/types.ts
+++ b/src/components/edit-pdf/types.ts
@@ -1,4 +1,4 @@
-export type ToolType = 'select' | 'text' | 'pen' | 'highlighter' | 'rect';
+export type ToolType = 'select' | 'text' | 'pen' | 'highlighter' | 'rect' | 'redact';
 
 export interface BaseAnnotation {
   id: string;

--- a/src/lib/constants/tools.ts
+++ b/src/lib/constants/tools.ts
@@ -69,6 +69,17 @@ export const PDF_TOOLS: PDFTool[] = [
     acceptedTypes: [FILE_TYPES.HTML]
   },
   {
+    id: 'edit',
+    title: 'Edit PDF',
+    description: 'Annotate or add new text and shapes to your PDF',
+    icon: 'edit-3',
+    href: '/edit-pdf',
+    features: ['Text editing', 'Freehand & highlight', 'Shapes & export'],
+    maxFiles: 1,
+    maxFileSize: MAX_FILE_SIZES.PDF,
+    acceptedTypes: [FILE_TYPES.PDF]
+  },
+  {
     id: 'rotate',
     title: 'Rotate PDF',
     description: 'Rotate pages in your PDF document',


### PR DESCRIPTION
## Purpose

Users reported multiple issues with PDF editing functionality:
- Tools only annotated instead of editing existing text
- Cursor alignment problems with tool placement
- Need for proper edit mode to modify existing PDF content
- Request for research into PDF text scanning and editing capabilities

This PR addresses these concerns by implementing a comprehensive PDF editor with both annotation and editing modes.

## Code changes

- **New PDF Editor Page** (`src/app/edit-pdf/page.tsx`): Created dedicated page for PDF editing functionality
- **PDF Editor Component** (`src/components/edit-pdf/pdf-editor.tsx`): 
  - Implemented dual-mode system (annotate/edit) to distinguish between adding new content and modifying existing text
  - Added comprehensive annotation tools: text, pen, highlighter, rectangles, and redaction
  - Implemented proper cursor alignment for tool placement
  - Added undo/redo functionality and export capabilities
  - Integrated drag-drop file upload with PDF rendering
- **Editor Toolbar** (`src/components/edit-pdf/toolbar.tsx`): Created toolbar with mode switching and tool selection
- **Type Definitions** (`src/components/edit-pdf/types.ts`): Defined TypeScript interfaces for annotations and editor state
- **Tool Registration** (`src/lib/constants/tools.ts`): Added PDF editor to the available tools list

The implementation provides both annotation capabilities for adding new content and lays groundwork for future text editing features.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/21f7dd8f32b84212955f430b5036dc66/nova-field)

👀 [Preview Link](https://21f7dd8f32b84212955f430b5036dc66-nova-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>21f7dd8f32b84212955f430b5036dc66</projectId>-->
<!--<branchName>nova-field</branchName>-->